### PR TITLE
Improve responsive design across all viewports

### DIFF
--- a/src/components/About.astro
+++ b/src/components/About.astro
@@ -36,7 +36,7 @@ const experiences = [
 ];
 ---
 
-<section id="about" class="bg-brand-accent py-6">
+<section id="about" class="bg-brand-accent py-8 sm:py-10 md:py-12">
   <!-- Marquee Text -->
   <Marquee />
 
@@ -48,25 +48,30 @@ const experiences = [
         <!-- Section Title -->
         <h2
           data-animate
-          class="text-brand-dark mb-8 text-center text-4xl font-black md:mb-12 md:text-5xl lg:text-right lg:text-6xl"
+          class="text-brand-dark mb-4 text-center text-4xl font-black sm:mb-6 sm:text-5xl md:mb-8 lg:text-right lg:text-6xl"
         >
           <div>About</div>
           <div>Me</div>
         </h2>
-        <div class="flex justify-center lg:block">
-          <div data-animate class="overflow-hidden">
+        <div
+          class="flex flex-col items-center gap-4 sm:flex-row sm:items-start sm:justify-center sm:gap-6 lg:block lg:gap-0"
+        >
+          <div
+            data-animate
+            class="aspect-[237/414] w-full max-w-[280px] overflow-hidden sm:w-1/2 sm:max-w-none lg:ml-auto lg:w-auto lg:max-w-[237px]"
+          >
             <Image
               src={aboutImage1}
               alt="Edward Guevarra"
               width={237}
               height={414}
               loading="eager"
-              class="ml-auto h-[414px] w-[237px] object-cover"
+              class="h-full w-full object-cover"
             />
           </div>
           <div
             data-animate
-            class="animate-delay-200 mt-0 overflow-hidden lg:-mt-50"
+            class="animate-delay-200 aspect-[237/414] w-full max-w-[280px] overflow-hidden sm:w-1/2 sm:max-w-none lg:-mt-50 lg:w-[237px] lg:max-w-none"
           >
             <Image
               src={aboutImage2}
@@ -74,20 +79,26 @@ const experiences = [
               width={237}
               height={414}
               loading="lazy"
-              class="h-[414px] w-[237px] object-cover"
+              class="h-full w-full object-cover"
             />
           </div>
         </div>
       </div>
 
       <!-- Combined Column - Biography, Experience Timeline, Hobbies, and Job Roles -->
-      <div class="flex flex-col gap-6 pt-0 md:gap-16 lg:pt-47">
+      <div class="flex w-full flex-col gap-8 pt-0 md:gap-12 lg:pt-47">
         <!-- Two Column Grid for Biography and Hobbies -->
-        <div class="grid grid-cols-1 gap-8 md:grid-cols-2">
+        <div class="grid grid-cols-1 gap-6 md:grid-cols-2 md:gap-8">
+          <h2
+            class="text-brand-dark order-1 block text-center text-4xl font-black sm:text-5xl md:order-none md:hidden lg:text-right lg:text-6xl"
+          >
+            Bio
+          </h2>
+
           <!-- Biography Column -->
           <div
             data-animate
-            class="text-brand-dark animate-delay-100 text-sm leading-relaxed md:text-base"
+            class="text-brand-dark animate-delay-100 order-2 text-sm leading-relaxed md:order-none md:text-base"
           >
             <p>
               Hey there! I'm Edward Guevarra, a senior full-stack developer
@@ -101,15 +112,9 @@ const experiences = [
             </p>
           </div>
 
-          <h2
-            class="text-brand-dark my-6 block text-center text-4xl font-black md:mb-12 md:hidden md:text-5xl lg:text-right lg:text-6xl"
-          >
-            Bio
-          </h2>
-
           <!-- Hobbies Column -->
-          <div data-animate class="animate-delay-200">
-            <div class="grid grid-cols-1 gap-6 md:flex md:flex-col md:gap-6">
+          <div data-animate class="animate-delay-200 order-3 md:order-none">
+            <div class="flex flex-col gap-3 sm:gap-4 md:gap-6">
               {
                 hobbies.map((hobby, index) => {
                   const delayClasses = [
@@ -134,13 +139,13 @@ const experiences = [
         </div>
 
         <h2
-          class="text-brand-dark my-6 block text-center text-4xl font-black md:hidden md:text-5xl lg:text-right lg:text-6xl"
+          class="text-brand-dark block text-center text-4xl font-black sm:text-5xl md:hidden lg:text-right lg:text-6xl"
         >
           Experiences
         </h2>
 
         <!-- Experience Timeline and Job Roles Paired -->
-        <div class="grid grid-cols-1 gap-6 md:block md:space-y-4">
+        <div class="flex flex-col gap-6 md:gap-4">
           {
             experiences.map((experience, index) => {
               const delayClasses = [
@@ -152,10 +157,10 @@ const experiences = [
               return (
                 <div
                   data-animate
-                  class={`flex flex-col items-center justify-between gap-4 md:flex-row ${delayClasses[index] || ""}`}
+                  class={`flex flex-col items-stretch justify-between gap-3 sm:items-center md:flex-row ${delayClasses[index] || ""}`}
                 >
                   <OutlineButton
-                    class="w-full md:w-auto"
+                    class="w-full sm:w-auto"
                     text={experience.period}
                     data-testid={`experience-button-${index}`}
                   />

--- a/src/components/Blog.astro
+++ b/src/components/Blog.astro
@@ -3,37 +3,44 @@ import OutlineButton from "./buttons/OutlineButton.astro";
 import { Image } from "astro:assets";
 ---
 
-<section id="blog" class="bg-brand-accent text-brand-dark py-20">
+<section
+  id="blog"
+  class="bg-brand-accent text-brand-dark py-12 sm:py-16 md:py-20"
+>
   <div class="container">
-    <div class="ml-auto flex max-w-3xl flex-col gap-6">
+    <div class="flex flex-col gap-6 md:ml-auto md:max-w-3xl">
       <!-- Text -->
-      <div data-animate class="text-right text-sm font-semibold">
-        <div>Want to learn some practical programming tips and tricks?</div>
-        <div>
-          Check out my blog where I share insights, tutorials, and lessons
-        </div>
-        <div>
-          I've learned from real projects, whether you're just starting out or
-        </div>
-        <div>looking to sharpen your skills!</div>
+      <div
+        data-animate
+        class="text-center text-sm leading-relaxed font-semibold md:text-right"
+      >
+        <p>
+          Want to learn some practical programming tips and tricks? Check out my
+          blog where I share insights, tutorials, and lessons I've learned from
+          real projects, whether you're just starting out or looking to sharpen
+          your skills!
+        </p>
       </div>
 
       <!-- Button -->
-      <div data-animate class="animate-delay-200">
-        <a href="/blog" class="ml-auto block w-fit">
-          <OutlineButton text="Checkout Blog" />
+      <div
+        data-animate
+        class="animate-delay-200 flex justify-center md:justify-end"
+      >
+        <a href="/blog" class="block w-full max-w-xs sm:w-fit sm:max-w-none">
+          <OutlineButton text="Checkout Blog" class="w-full sm:w-auto" />
         </a>
       </div>
 
       <!-- Images container -->
-      <div class="flex justify-end gap-6">
+      <div class="grid grid-cols-1 gap-4 sm:grid-cols-2 sm:gap-6">
         <div data-animate class="animate-delay-300">
           <Image
             src="https://picsum.photos/seed/blog1/322/227.jpg"
             alt=""
             width="322"
             height="227"
-            class="rounded-lg object-cover shadow-[6px_6px_6px_0px_rgba(0,0,0,0.25)]"
+            class="h-auto w-full rounded-lg object-cover shadow-[6px_6px_6px_0px_rgba(0,0,0,0.25)]"
           />
         </div>
         <div data-animate class="animate-delay-400">
@@ -42,7 +49,7 @@ import { Image } from "astro:assets";
             alt=""
             width="322"
             height="227"
-            class="rounded-lg object-cover shadow-[6px_6px_6px_0px_rgba(0,0,0,0.25)]"
+            class="h-auto w-full rounded-lg object-cover shadow-[6px_6px_6px_0px_rgba(0,0,0,0.25)]"
           />
         </div>
       </div>

--- a/src/components/Contact.astro
+++ b/src/components/Contact.astro
@@ -35,22 +35,27 @@ const contactLinks = [
 ];
 ---
 
-<section id="contact" class="bg-brand-dark pt-16 pb-18">
+<section
+  id="contact"
+  class="bg-brand-dark relative overflow-hidden pt-12 pb-16 sm:pt-16 sm:pb-20 md:pb-24 xl:pb-20"
+>
   <div class="relative container pt-0 xl:pt-20">
     <div
       class="flex flex-col flex-wrap items-center justify-between xl:flex-row xl:items-start"
     >
       <div
         data-animate
-        class="text-brand-accent pb-8 text-center text-6xl font-black lg:pb-0 xl:text-left"
+        class="text-brand-accent pb-6 text-center text-5xl font-black sm:pb-8 sm:text-6xl lg:pb-0 xl:text-left"
       >
         <div>Contact Me,</div>
         <div>Let's Talk</div>
       </div>
-      <div class="flex flex-col gap-20 pt-8 xl:pt-0">
+      <div
+        class="flex w-full flex-col gap-10 pt-6 sm:gap-12 sm:pt-8 md:gap-16 xl:w-auto xl:gap-20 xl:pt-0"
+      >
         <div
           data-animate
-          class="animate-delay-100 max-w-xl text-center text-sm text-white xl:text-right"
+          class="animate-delay-100 mx-auto max-w-xl text-center text-sm text-white xl:mx-0 xl:text-right"
         >
           <div>
             Got a project in mind? Need a developer to bring your ideas to life
@@ -61,17 +66,20 @@ const contactLinks = [
             Let's connect! Shoot me a message and let's make it happen.
           </div>
         </div>
-        <div class="flex flex-col gap-6">
+        <div class="flex flex-col items-center gap-4 sm:gap-6 xl:items-end">
           {
             contactLinks.map((link) => (
-              <div data-animate class={`animate-delay-${link.delay}`}>
+              <div
+                data-animate
+                class={`w-full max-w-sm animate-delay-${link.delay} sm:w-auto sm:max-w-none`}
+              >
                 <OutlineButton
                   text={link.text}
                   href={link.href}
                   icon={link.icon}
                   target={link.target}
                   color="white"
-                  class="mr-auto ml-auto md:mr-0"
+                  class="w-full sm:w-auto"
                 />
               </div>
             ))
@@ -81,9 +89,16 @@ const contactLinks = [
     </div>
     <div
       data-animate
-      class="animate-delay-300 absolute -bottom-55 left-0 hidden md:block"
+      class="animate-delay-300 pointer-events-none absolute bottom-0 left-0 hidden w-56 md:-bottom-20 md:block lg:-bottom-32 lg:w-72 xl:-bottom-40 xl:w-80"
+      aria-hidden="true"
     >
-      <Image src={contactIcon} alt="" width={437} height={445} />
+      <Image
+        src={contactIcon}
+        alt=""
+        width={437}
+        height={445}
+        class="h-auto w-full"
+      />
     </div>
   </div>
 </section>

--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -8,7 +8,7 @@ import { getNavigationItems } from "../services/navigation/config";
 const navItems = getNavigationItems(false);
 ---
 
-<footer class="bg-brand-dark mt-auto border-t border-white/10">
+<footer class="bg-brand-dark mt-auto overflow-hidden border-t border-white/10">
   <div class="relative container">
     <!-- Circle Background -->
     <Image
@@ -16,30 +16,28 @@ const navItems = getNavigationItems(false);
       alt=""
       width={1146}
       height={492}
-      class="absolute right-0 bottom-0 left-0 z-0 m-auto"
+      class="pointer-events-none absolute right-0 bottom-0 left-0 z-0 m-auto max-w-none"
     />
 
     <!-- Branding -->
     <div
-      class="text-brand-accent relative z-10 hidden py-16 text-center text-8xl font-black md:block"
+      class="text-brand-accent relative z-10 hidden py-12 text-center text-5xl leading-none font-black sm:block sm:text-6xl md:py-16 md:text-7xl lg:text-8xl"
     >
       edwrd.dev
     </div>
 
     <!-- Footer Content -->
     <div
-      class="flex flex-col flex-wrap items-center justify-between gap-8 pt-20 pb-10 lg:flex-row lg:pt-40"
+      class="relative z-10 flex flex-col flex-wrap items-center justify-between gap-6 pt-12 pb-8 sm:gap-8 sm:pt-16 md:pt-20 lg:flex-row lg:pt-32 xl:pt-40"
     >
       <!-- Logo -->
-      <div
-        class="text-brand-lime relative z-10 text-center text-xl font-bold lg:text-left"
-      >
+      <div class="text-brand-lime text-center text-xl font-bold lg:text-left">
         edwrd
       </div>
 
       <!-- Navigation Links -->
       <nav
-        class="relative z-10 flex items-center justify-center gap-4 lg:gap-[100px]"
+        class="flex flex-wrap items-center justify-center gap-x-5 gap-y-3 sm:gap-x-8 lg:gap-x-12 xl:gap-x-[100px]"
       >
         {
           navItems.map((item) => (
@@ -60,13 +58,8 @@ const navItems = getNavigationItems(false);
       </nav>
 
       <!-- CTA Button -->
-      <div class="relative z-10 flex justify-center lg:justify-end">
-        <FilledButton
-          href="/#contact"
-          text="Let's Talk"
-          color="white"
-          class="ml-auto"
-        />
+      <div class="flex justify-center lg:justify-end">
+        <FilledButton href="/#contact" text="Let's Talk" color="white" />
       </div>
     </div>
   </div>

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -13,7 +13,7 @@ const isHomePage = Astro.url.pathname === "/";
 const navItems = getNavigationItems(isHomePage);
 ---
 
-<header class="bg-brand-dark py-6 lg:py-12">
+<header class="bg-brand-dark py-5 sm:py-6 lg:py-10 xl:py-12">
   <div class="container">
     <!-- Mobile Header -->
     <div class="flex items-center justify-between lg:hidden">
@@ -39,7 +39,7 @@ const navItems = getNavigationItems(isHomePage);
     </div>
 
     <!-- Desktop Header -->
-    <div class="hidden items-center lg:grid lg:grid-cols-3">
+    <div class="hidden items-center lg:grid lg:grid-cols-3 lg:gap-4">
       <!-- Logo -->
       <a
         href="/"
@@ -50,7 +50,7 @@ const navItems = getNavigationItems(isHomePage);
 
       <!-- Navigation Links -->
       <nav
-        class="relative z-10 flex items-center justify-center gap-[100px]"
+        class="relative z-10 flex items-center justify-center gap-8 xl:gap-[100px]"
         role="navigation"
         aria-label="Main navigation"
       >

--- a/src/components/Hero.astro
+++ b/src/components/Hero.astro
@@ -6,28 +6,11 @@ import FilledButton from "./buttons/FilledButton.astro";
 ---
 
 <section
-  class="bg-brand-dark relative flex min-h-[calc(100dvh-88px)] flex-1 flex-col items-center justify-center py-4 md:min-h-auto md:py-8 lg:min-h-auto"
+  class="bg-brand-dark relative flex min-h-[calc(100dvh-88px)] flex-1 flex-col items-center justify-center overflow-hidden py-4 sm:py-6 md:min-h-[620px] md:overflow-visible md:py-8 lg:min-h-[640px]"
 >
-  <!-- Hero Image - Immediately discoverable for LCP optimization -->
-  <div
-    class="-bottom-20 z-50 h-[350px] w-[200px] contain-layout md:absolute md:-bottom-20 md:h-[350px] md:w-[200px]"
-  >
-    <Image
-      src={heroImage}
-      alt="Edward Guevarra"
-      width={200}
-      height={350}
-      priority
-      fetchpriority="high"
-      loading="eager"
-      decoding="sync"
-      class="aspect-200/350 h-full w-full object-cover"
-    />
-  </div>
-
   <!-- Circle Background -->
   <Image
-    class="absolute right-0 bottom-0 left-0 z-0 m-auto"
+    class="pointer-events-none absolute right-0 bottom-0 left-0 z-0 m-auto max-w-none"
     src={bgCircle}
     alt=""
     width={1146}
@@ -36,7 +19,10 @@ import FilledButton from "./buttons/FilledButton.astro";
   />
 
   <!-- Decorative arcs in bottom-right corner -->
-  <div class="absolute right-0 bottom-0 h-96 w-96 opacity-20">
+  <div
+    class="pointer-events-none absolute right-0 bottom-0 hidden h-96 w-96 opacity-20 sm:block"
+    aria-hidden="true"
+  >
     <div
       class="border-brand-dark absolute right-0 bottom-0 h-64 w-64 rounded-full border-2"
     >
@@ -51,67 +37,84 @@ import FilledButton from "./buttons/FilledButton.astro";
     </div>
   </div>
 
-  <!-- Centered Title -->
-  <div class="z-10 mb-8 text-center md:mb-6">
+  <!-- Centered Title - sits behind the hero image on tablet+ -->
+  <div class="relative z-10 order-2 mb-6 text-center sm:mb-8 md:order-none md:mb-6">
     <h1
       data-animate
-      class="text-brand-accent mb-1 text-6xl leading-12 font-black tracking-normal sm:text-8xl sm:leading-16"
+      class="text-brand-accent mb-1 text-5xl leading-none font-black tracking-normal sm:text-7xl md:text-8xl md:leading-[1.05]"
     >
       edwrd
     </h1>
     <h2
       data-animate
-      class="text-brand-accent animate-delay-100 mb-1 text-6xl leading-12 font-black tracking-normal sm:text-8xl sm:leading-16"
+      class="text-brand-accent animate-delay-100 mb-1 text-5xl leading-none font-black tracking-normal sm:text-7xl md:text-8xl md:leading-[1.05]"
     >
       dev
     </h2>
     <h3
       data-animate
-      class="text-brand-accent animate-delay-200 text-6xl leading-12 font-black tracking-normal sm:text-8xl sm:leading-16"
+      class="text-brand-accent animate-delay-200 text-5xl leading-none font-black tracking-normal sm:text-7xl md:text-8xl md:leading-[1.05]"
     >
       edwrd
     </h3>
   </div>
 
+  <!-- Hero Image - positioned in front of title on tablet+ for the overlapping effect -->
+  <div
+    class="relative z-30 order-1 mb-6 h-[280px] w-[160px] shrink-0 contain-layout sm:h-[320px] sm:w-[185px] md:absolute md:-bottom-16 md:left-1/2 md:order-none md:mb-0 md:h-[380px] md:w-[217px] md:-translate-x-1/2 lg:-bottom-20 lg:h-[440px] lg:w-[251px]"
+  >
+    <Image
+      src={heroImage}
+      alt="Edward Guevarra"
+      width={200}
+      height={350}
+      priority
+      fetchpriority="high"
+      loading="eager"
+      decoding="sync"
+      class="aspect-200/350 h-full w-full object-cover"
+    />
+  </div>
+
   <!-- Content Grid -->
-  <div class="z-10 container">
-    <div class="grid grid-cols-1 gap-4 md:grid-cols-2 md:gap-6">
+  <div class="relative z-20 order-3 container md:order-none">
+    <div class="grid grid-cols-1 gap-6 md:grid-cols-2 md:gap-8">
       <!-- Right Content Block - Statistics (shown first on mobile) -->
       <div
-        class="order-first flex flex-row items-center justify-center space-x-6 text-center md:order-last md:flex-col md:items-end md:justify-end md:space-y-4 md:space-x-0 md:text-right"
+        class="order-first flex flex-row flex-wrap items-center justify-center gap-x-6 gap-y-4 text-center md:order-last md:flex-col md:flex-nowrap md:items-end md:justify-end md:gap-y-4 md:text-right"
       >
         <div data-animate class="animate-delay-300 text-center md:text-right">
           <div
-            class="text-2xl leading-8 font-semibold tracking-normal text-white"
+            class="text-xl leading-7 font-semibold tracking-normal text-white sm:text-2xl sm:leading-8"
           >
             10+
           </div>
           <div
-            class="mt-1 text-sm leading-5 font-normal tracking-normal text-white"
+            class="mt-1 text-xs leading-4 font-normal tracking-normal text-white sm:text-sm sm:leading-5"
           >
             years of experience
           </div>
         </div>
         <div data-animate class="animate-delay-400 text-center md:text-right">
           <div
-            class="text-2xl leading-8 font-semibold tracking-normal text-white"
+            class="text-xl leading-7 font-semibold tracking-normal text-white sm:text-2xl sm:leading-8"
           >
             20+
           </div>
           <div
-            class="mt-1 text-sm leading-5 font-normal tracking-normal text-white"
+            class="mt-1 text-xs leading-4 font-normal tracking-normal text-white sm:text-sm sm:leading-5"
           >
             projects completed
           </div>
         </div>
         <div data-animate class="animate-delay-500 text-center md:text-right">
           <div
-            class="text-2xl leading-8 font-semibold tracking-normal text-white"
+            class="text-xl leading-7 font-semibold tracking-normal text-white sm:text-2xl sm:leading-8"
           >
             9999+
           </div>
           <div
-            class="mt-1 text-sm leading-5 font-normal tracking-normal text-white"
+            class="mt-1 text-xs leading-4 font-normal tracking-normal text-white sm:text-sm sm:leading-5"
           >
             errors debugged
           </div>
@@ -120,11 +123,11 @@ import FilledButton from "./buttons/FilledButton.astro";
 
       <!-- Left Content Block (shown second on mobile) -->
       <div
-        class="order-last flex flex-col justify-end space-y-6 text-center md:order-first md:text-left"
+        class="order-last flex flex-col justify-end gap-4 text-center sm:gap-6 md:order-first md:text-left"
       >
         <p
           data-animate
-          class="animate-delay-300 mx-auto max-w-[240px] text-sm leading-5 font-normal tracking-normal text-white md:mx-0 lg:max-w-[352px]"
+          class="animate-delay-300 mx-auto max-w-[260px] text-sm leading-5 font-normal tracking-normal text-white sm:max-w-[320px] md:mx-0 md:max-w-[280px] lg:max-w-[352px]"
         >
           Experienced senior dev who always wants to learn and build stuffs. Got
           a project in mind? Send me a message!

--- a/src/components/Projects.astro
+++ b/src/components/Projects.astro
@@ -8,36 +8,43 @@ const projects = await getCollection("projects");
 type ProjectEntry = CollectionEntry<"projects">;
 ---
 
-<section id="projects" class="bg-brand-accent pt-6 pb-20">
-  <div class="container mx-auto px-4">
-    <div class="flex flex-col items-center justify-between md:flex-row">
+<section id="projects" class="bg-brand-accent pt-8 pb-16 sm:pt-10 md:pb-20">
+  <div class="container">
+    <div
+      class="flex flex-col items-center justify-between gap-8 md:flex-row md:gap-6"
+    >
       <!-- Left column for Skill/Tools button and additional content -->
-      <div class="mb-4 w-full md:mb-0 md:w-1/2">
+      <div class="flex w-full flex-col items-center md:w-1/2 md:items-start">
         <div data-animate>
           <OutlineButton text="Skill / Tools" />
         </div>
-        <div data-animate class="animate-delay-200 mt-8">
+        <div
+          data-animate
+          class="animate-delay-200 mt-6 w-full max-w-md sm:mt-8"
+        >
           <Image
             src={toolsImage}
             alt="Tools"
             width={500}
             height={500}
-            class="w-full max-w-md"
+            class="h-auto w-full"
           />
         </div>
       </div>
 
       <!-- Right column for title -->
-      <div class="w-full pt-8 text-center md:w-1/2 md:pt-0 md:text-right">
+      <div class="w-full text-center md:w-1/2 md:text-right">
         <h2
           data-animate
-          class="font-inter text-brand-dark animate-delay-100 text-4xl leading-tight font-black tracking-normal md:text-5xl md:leading-snug lg:text-6xl lg:leading-[72px]"
+          class="font-inter text-brand-dark animate-delay-100 text-4xl leading-tight font-black tracking-normal sm:text-5xl sm:leading-snug lg:text-6xl lg:leading-[72px]"
         >
           My Projects/<br />Works
         </h2>
       </div>
     </div>
-    <div class="grid grid-cols-1 gap-6 py-6 md:grid-cols-3">
+    <div
+      class="grid grid-cols-1 gap-6 py-8 sm:grid-cols-2 sm:py-10 lg:grid-cols-3"
+    >
       {
         projects.map((project: ProjectEntry, index: number) => {
           const delayClasses = [

--- a/src/components/Prose.astro
+++ b/src/components/Prose.astro
@@ -3,7 +3,7 @@
 ---
 
 <div
-  class="prose prose-lg prose-headings:text-brand-dark prose-headings:font-bold prose-p:text-brand-dark/90 prose-a:text-brand-dark prose-a:underline prose-strong:text-brand-dark prose-strong:font-bold prose-code:text-brand-dark prose-code:px-1 prose-code:py-0.5 prose-code:rounded prose-pre:bg-brand-dark prose-pre:text-white prose-blockquote:border-l-4 prose-blockquote:border-brand-lime prose-blockquote:pl-4 prose-blockquote:ml-0 prose-blockquote:italic prose-blockquote:text-brand-dark prose-blockquote:opacity-80 prose-img:rounded-lg prose-img:my-8 prose-ul:mb-5 prose-ol:mb-5 prose-li:my-1 max-w-none"
+  class="prose sm:prose-lg prose-headings:text-brand-dark prose-headings:font-bold prose-p:text-brand-dark/90 prose-a:text-brand-dark prose-a:underline prose-strong:text-brand-dark prose-strong:font-bold prose-code:text-brand-dark prose-code:px-1 prose-code:py-0.5 prose-code:rounded prose-pre:bg-brand-dark prose-pre:text-white prose-blockquote:border-l-4 prose-blockquote:border-brand-lime prose-blockquote:pl-4 prose-blockquote:ml-0 prose-blockquote:italic prose-blockquote:text-brand-dark prose-blockquote:opacity-80 prose-img:rounded-lg prose-img:my-8 prose-ul:mb-5 prose-ol:mb-5 prose-li:my-1 max-w-none break-words"
 >
   <slot />
 </div>
@@ -13,5 +13,15 @@
     color: white;
     background: transparent;
     padding: 0;
+  }
+
+  .prose pre {
+    overflow-x: auto;
+    max-width: 100%;
+  }
+
+  .prose img {
+    height: auto;
+    max-width: 100%;
   }
 </style>

--- a/src/components/buttons/FilledButton.astro
+++ b/src/components/buttons/FilledButton.astro
@@ -13,7 +13,7 @@ export interface Props {
 const { text, class: className = "", href, icon, color, target } = Astro.props;
 
 const baseClasses =
-  "w-fit px-[54px] py-[9px] rounded-[50px] border font-semibold text-[14px] leading-[22px] tracking-normal text-center hover:opacity-80 transition-opacity flex items-center justify-center gap-2 cursor-pointer";
+  "w-fit max-w-full px-8 py-[9px] rounded-[50px] border font-semibold text-[14px] leading-[22px] tracking-normal text-center hover:opacity-80 transition-opacity flex items-center justify-center gap-2 cursor-pointer sm:px-[54px]";
 
 const colorClasses =
   color === "white"

--- a/src/components/buttons/OutlineButton.astro
+++ b/src/components/buttons/OutlineButton.astro
@@ -22,7 +22,7 @@ const {
 } = Astro.props as Props;
 
 const baseClasses =
-  "w-fit px-[54px] py-[9px] rounded-[50px] border font-semibold text-[14px] leading-[22px] tracking-normal text-center hover:opacity-80 transition-opacity flex items-center justify-center gap-2 cursor-pointer";
+  "w-fit max-w-full px-8 py-[9px] rounded-[50px] border font-semibold text-[14px] leading-[22px] tracking-normal text-center hover:opacity-80 transition-opacity flex items-center justify-center gap-2 cursor-pointer sm:px-[54px]";
 
 const colorClasses =
   color === "white"

--- a/src/pages/404.astro
+++ b/src/pages/404.astro
@@ -13,9 +13,12 @@ import PageLayout from "../layouts/PageLayout.astro";
   twitterDescription="The page you're looking for doesn't exist or has been moved."
 >
   <section
-    class="bg-brand-dark relative flex min-h-[calc(100vh-88px)] flex-1 flex-col items-center justify-center py-4 md:min-h-auto md:py-8"
+    class="bg-brand-dark relative flex min-h-[calc(100dvh-88px)] flex-1 flex-col items-center justify-center overflow-hidden py-8 sm:py-12 md:min-h-[600px]"
   >
-    <div class="absolute right-0 bottom-0 h-96 w-96 opacity-20">
+    <div
+      class="pointer-events-none absolute right-0 bottom-0 hidden h-96 w-96 opacity-20 sm:block"
+      aria-hidden="true"
+    >
       <div
         class="border-brand-accent absolute right-0 bottom-0 h-64 w-64 rounded-full border-2"
       >
@@ -30,25 +33,25 @@ import PageLayout from "../layouts/PageLayout.astro";
       </div>
     </div>
 
-    <div class="z-10 container">
+    <div class="relative z-10 container">
       <div class="mx-auto max-w-2xl text-center">
         <h1
           data-animate
-          class="text-brand-lime mb-4 text-8xl leading-none font-black tracking-tight sm:text-9xl lg:text-[160px]"
+          class="text-brand-lime mb-4 text-7xl leading-none font-black tracking-tight sm:text-8xl md:text-9xl lg:text-[160px]"
         >
           404
         </h1>
 
         <h2
           data-animate
-          class="animate-delay-100 text-brand-accent mb-6 text-3xl leading-tight font-bold sm:text-4xl lg:text-5xl"
+          class="animate-delay-100 text-brand-accent mb-4 text-2xl leading-tight font-bold sm:mb-6 sm:text-3xl md:text-4xl lg:text-5xl"
         >
           Page Not Found
         </h2>
 
         <p
           data-animate
-          class="animate-delay-200 mb-10 text-base leading-relaxed text-white md:text-lg"
+          class="animate-delay-200 mx-auto mb-8 max-w-md text-sm leading-relaxed text-white sm:mb-10 sm:text-base md:max-w-none md:text-lg"
         >
           Oops! The page you're looking for doesn't exist or has been moved.
           Don't worry, let's get you back on track.
@@ -56,19 +59,27 @@ import PageLayout from "../layouts/PageLayout.astro";
 
         <div
           data-animate
-          class="animate-delay-300 mb-12 flex flex-col items-center gap-4 sm:flex-row sm:justify-center"
+          class="animate-delay-300 mb-8 flex flex-col items-center gap-3 sm:mb-12 sm:flex-row sm:justify-center sm:gap-4"
         >
-          <a href="/">
-            <FilledButton text="Back to Home" color="lime" />
+          <a href="/" class="w-full max-w-xs sm:w-auto sm:max-w-none">
+            <FilledButton
+              text="Back to Home"
+              color="lime"
+              class="w-full sm:w-auto"
+            />
           </a>
-          <a href="/blog">
-            <OutlineButton text="View Blog" color="white" />
+          <a href="/blog" class="w-full max-w-xs sm:w-auto sm:max-w-none">
+            <OutlineButton
+              text="View Blog"
+              color="white"
+              class="w-full sm:w-auto"
+            />
           </a>
         </div>
 
         <div
           data-animate
-          class="animate-delay-400 flex flex-wrap justify-center gap-6 text-sm font-semibold"
+          class="animate-delay-400 flex flex-wrap items-center justify-center gap-x-4 gap-y-2 text-sm font-semibold sm:gap-6"
         >
           <a
             href="/#about"

--- a/src/pages/blog/[id].astro
+++ b/src/pages/blog/[id].astro
@@ -69,11 +69,11 @@ const { Content } = await render(post);
     }
   </style>
 
-  <div class="container mx-auto px-4 py-12 lg:py-20">
-    <div class="mb-8" data-animate>
+  <div class="container py-10 sm:py-12 lg:py-20">
+    <div class="mb-6 sm:mb-8" data-animate>
       <a
         href="/blog"
-        class="text-brand-dark inline-flex items-center gap-2 font-semibold transition-opacity hover:opacity-80"
+        class="text-brand-dark inline-flex items-center gap-2 text-sm font-semibold transition-opacity hover:opacity-80 sm:text-base"
       >
         <svg
           class="h-5 w-5"
@@ -92,29 +92,29 @@ const { Content } = await render(post);
     </div>
 
     <article
-      class="rounded-lg bg-white p-6 shadow-lg md:p-8 lg:p-12"
+      class="rounded-lg bg-white p-5 shadow-lg sm:p-6 md:p-8 lg:p-12"
       data-animate
     >
-      <div class="mb-8" data-animate>
+      <div class="mb-6 sm:mb-8" data-animate>
         <Image
           src={post.data.featuredImage}
           alt={post.data.featuredImageAlt}
           width={800}
           height={400}
-          class="w-full rounded-lg object-cover shadow-[6px_6px_6px_0px_rgba(0,0,0,0.25)]"
+          class="aspect-[2/1] w-full rounded-lg object-cover shadow-[6px_6px_6px_0px_rgba(0,0,0,0.25)]"
         />
       </div>
 
       <h1
         data-animate
-        class="font-inter text-brand-dark animate-delay-100 mb-4 text-3xl leading-tight font-black md:text-4xl lg:text-5xl"
+        class="font-inter text-brand-dark animate-delay-100 mb-3 text-2xl leading-tight font-black sm:mb-4 sm:text-3xl md:text-4xl lg:text-5xl"
       >
         {post.data.title}
       </h1>
 
       <div
         data-animate
-        class="text-brand-dark/70 animate-delay-200 mb-6 flex flex-wrap items-center gap-4 text-sm"
+        class="text-brand-dark/70 animate-delay-200 mb-4 flex flex-wrap items-center gap-x-3 gap-y-1 text-xs sm:mb-6 sm:gap-4 sm:text-sm"
       >
         <time datetime={post.data.date.toISOString()}
           >{formatDate(post.data.date)}</time
@@ -123,7 +123,10 @@ const { Content } = await render(post);
         <span>By {post.data.author}</span>
       </div>
 
-      <div data-animate class="animate-delay-300 mb-8 flex flex-wrap gap-2">
+      <div
+        data-animate
+        class="animate-delay-300 mb-6 flex flex-wrap gap-2 sm:mb-8"
+      >
         {
           post.data.tags.map((tag) => (
             <span class="bg-brand-lime text-brand-dark rounded-full px-3 py-1 text-xs font-semibold">
@@ -139,7 +142,10 @@ const { Content } = await render(post);
         </Prose>
       </div>
 
-      <div class="border-brand-dark/10 mt-12 border-t pt-8" data-animate>
+      <div
+        class="border-brand-dark/10 mt-10 border-t pt-6 sm:mt-12 sm:pt-8"
+        data-animate
+      >
         <a href="/blog">
           <OutlineButton text="Back to Blog" />
         </a>

--- a/src/pages/blog/index.astro
+++ b/src/pages/blog/index.astro
@@ -24,17 +24,17 @@ const postsData = sortedPosts.map((post) => ({
   description="Practical programming tips, tutorials, and insights from real projects"
   mainClass="bg-brand-accent min-h-screen"
 >
-  <div class="container mx-auto px-4 py-12 lg:py-20">
-    <div class="mb-12 lg:mb-16">
+  <div class="container py-10 sm:py-12 lg:py-20">
+    <div class="mb-8 sm:mb-12 lg:mb-16">
       <h1
         data-animate
-        class="font-inter text-brand-dark mb-4 text-4xl leading-tight font-black md:text-5xl lg:text-6xl"
+        class="font-inter text-brand-dark mb-3 text-4xl leading-tight font-black sm:mb-4 sm:text-5xl lg:text-6xl"
       >
         Blog
       </h1>
       <p
         data-animate
-        class="text-brand-dark animate-delay-100 max-w-2xl text-lg md:text-xl"
+        class="text-brand-dark animate-delay-100 max-w-2xl text-base sm:text-lg md:text-xl"
       >
         Practical programming tips, tutorials, and insights from real projects.
         Whether you're just starting out or looking to sharpen your skills!
@@ -48,7 +48,7 @@ const postsData = sortedPosts.map((post) => ({
       </a>
     </div>
 
-    <div class="mb-8" data-animate>
+    <div class="mb-6 sm:mb-8" data-animate>
       <div class="relative max-w-2xl">
         <svg
           class="text-brand-dark/60 absolute top-1/2 left-4 h-5 w-5 -translate-y-1/2"
@@ -84,7 +84,7 @@ const postsData = sortedPosts.map((post) => ({
       sortedPosts.length > 0 ? (
         <div
           id="blog-posts-grid"
-          class="grid grid-cols-1 gap-8 md:grid-cols-2 lg:grid-cols-3"
+          class="grid grid-cols-1 gap-6 sm:grid-cols-2 sm:gap-8 lg:grid-cols-3"
         >
           {sortedPosts.map((post: BlogEntry, index: number) => {
             const delayClasses = [

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -5,6 +5,15 @@ html {
   scroll-behavior: smooth;
 }
 
+body {
+  overflow-x: hidden;
+}
+
+img {
+  max-width: 100%;
+  height: auto;
+}
+
 @theme {
   --color-brand-dark: #251893;
   --color-brand-lime: #dfff00;
@@ -16,9 +25,16 @@ html {
   max-width: 1280px;
   margin-left: auto;
   margin-right: auto;
-  padding-left: 1.5rem;
-  padding-right: 1.5rem;
+  padding-left: 1rem;
+  padding-right: 1rem;
   width: 100%;
+}
+
+@media (min-width: 480px) {
+  .container {
+    padding-left: 1.5rem;
+    padding-right: 1.5rem;
+  }
 }
 
 @media (min-width: 640px) {


### PR DESCRIPTION
## Summary

Audited the site at 320 / 375 / 640 / 768 / 1024 / 1280 / 1920 px and fixed layout breaks, overlaps, and overflow issues across every page and component. No horizontal scroll at any size; all 199 unit tests pass; production build clean.

## What changed

**Hero** — Restored the original layered look (portrait in front of the `edwrd / dev / edwrd` title at \`md:+\` via z-index ordering and \`-bottom-16/-20\`), with the image overflowing into the marquee. On mobile the image stacks above the title naturally. Stats row now wraps at narrow widths.

**About** — Replaced fixed \`237×414\` image dimensions with \`aspect-ratio + max-w-[280px]\` so images shrink fluidly on mobile, side-by-side at \`sm:\`, and keep the staggered overlap at \`lg:\`. Reordered Bio heading on mobile.

**Projects** — Card grid now \`1 → 2 → 3\` columns at \`sm:/lg:\` (was \`1 → 3\` at \`md:\`, which was cramped at 768 px).

**Contact** — Decorative paper airplane was \`437×445\` with \`-bottom-55\` bleeding into the next section. Now scales \`w-56 → w-72 → w-80\`, clipped via \`overflow-hidden\`.

**Blog** — Mobile text alignment changed from awkward \`text-right\` to centered. Two preview images switch from fixed-width side-by-side to \`grid-cols-1 sm:grid-cols-2\` so they're full-width on mobile.

**Header / Footer** — Tightened nav gap (\`gap-8 xl:gap-[100px]\` instead of always \`gap-[100px]\`); footer nav uses \`flex-wrap\` for narrow screens; footer brand scales \`5xl → 8xl\`.

**404 + blog pages** — Title scales \`7xl → 160px\`, decorative circles hidden \`<sm\`, full-width buttons on mobile, removed doubled \`container + px-4\` padding, prose responsive sizing with \`<pre>\` overflow guard.

**Buttons + global** — Replaced fixed \`px-[54px]\` with \`px-8 sm:px-[54px]\` + \`max-w-full\` so long text (e.g. emails) doesn't push past 320 px viewports. Added \`body { overflow-x: hidden }\`, intrinsic image rules, and a new \`<480px\` container padding tier.

## Test plan

- [x] Verified at 320, 375, 640, 768, 1024, 1280, 1920 — no horizontal overflow at any width
- [x] Hero, About, Projects, Contact, Blog sections checked at mobile/tablet/desktop
- [x] Blog index and blog detail pages checked
- [x] 404 page checked
- [x] \`npm run lint\` — clean
- [x] \`npm run test:run\` — 199/199 passing
- [x] \`npm run build\` — clean
- [x] \`npm run format\` applied
- [ ] Reviewer to spot-check on a real device if possible

🤖 Generated with [Claude Code](https://claude.com/claude-code)